### PR TITLE
Add PHP Class Diagram name to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This is an example of creating a class diagram from the directory for which you 
  * .github/workflows/php-class-diagram.yml
 
 ```
+name: PHP Class Diagram
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
An update to README.md was made to include the name of the PHP Class Diagram. This is added under the section where the workflow file .github/workflows/php-class-diagram.yml is described.